### PR TITLE
Add dependency on django-cms migrations to initial migrations

### DIFF
--- a/cmsplugin_zinnia/migrations/0001_initial.py
+++ b/cmsplugin_zinnia/migrations/0001_initial.py
@@ -4,7 +4,8 @@ from django.db import models
 
 
 class Migration(SchemaMigration):
-    depends_on = [('cms', '0001_initial')]
+    depends_on = [('zinnia', '0001_initial'),
+                  ('cms', '0001_initial')]
 
     def forwards(self, orm):
         # Adding model 'LatestEntriesPlugin'


### PR DESCRIPTION
If you migrate on a clean database, cmsplugin-zinnia migrations might run before django-cms
