### PR TITLE
Updated models.py for Django-CMS 2.2+

### DIFF
--- a/cmsplugin_zinnia/models.py
+++ b/cmsplugin_zinnia/models.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete
 from django.utils.translation import ugettext_lazy as _
 
 from tagging.models import Tag
-from cms.models import CMSPlugin
+from cms.models.pluginmodel import CMSPlugin
 from menus.menu_pool import menu_pool
 
 from zinnia.models import Entry


### PR DESCRIPTION
The location of CMSPlugin changed in 2.2 and has been updated accordingly. You had already updated it in cms_plugins.py, but not in models.py.
