### PR TITLE
Issue #20: Self-explanatory select options and help_text for Featured and Offset

### DIFF
--- a/cmsplugin_zinnia/models.py
+++ b/cmsplugin_zinnia/models.py
@@ -24,7 +24,7 @@ class LatestEntriesPlugin(CMSPlugin):
         _('featured'),
         blank=True, null=True,
         choices=((True, _('Show featured entries only')),
-                 (False, _('Hide features entries'))))
+                 (False, _('Hide featured entries'))))
     categories = models.ManyToManyField(
         'zinnia.Category', verbose_name=_('categories'),
         blank=True, null=True)


### PR DESCRIPTION
Make the new filter options Offset and Featured self-explanatory to avoid misunderstandings
