### PR TITLE
importing from models.x instead of models

### DIFF
--- a/cmsplugin_zinnia/admin.py
+++ b/cmsplugin_zinnia/admin.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from cms.plugin_rendering import render_placeholder
 from cms.admin.placeholderadmin import PlaceholderAdmin
 
-from zinnia.models import Entry
+from zinnia.models.entry import Entry
 from zinnia.admin.entry import EntryAdmin
 from zinnia.settings import ENTRY_BASE_MODEL
 

--- a/cmsplugin_zinnia/cms_plugins.py
+++ b/cmsplugin_zinnia/cms_plugins.py
@@ -9,8 +9,8 @@ from tagging.models import TaggedItem
 from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBase
 
-from zinnia.models import Entry
-from zinnia.models import Author
+from zinnia.models.entry import Entry
+from zinnia.models.author import Author
 from zinnia.managers import tags_published
 
 from cmsplugin_zinnia.models import RandomEntriesPlugin

--- a/cmsplugin_zinnia/menu.py
+++ b/cmsplugin_zinnia/menu.py
@@ -10,9 +10,9 @@ from menus.base import NavigationNode
 from menus.menu_pool import menu_pool
 from cms.menu_bases import CMSAttachMenu
 
-from zinnia.models import Entry
-from zinnia.models import Author
-from zinnia.models import Category
+from zinnia.models.entry import Entry
+from zinnia.models.author import Author
+from zinnia.models.category import Category
 from zinnia.managers import tags_published
 from cmsplugin_zinnia.settings import HIDE_ENTRY_MENU
 


### PR DESCRIPTION
in order to get cmsplugin_zinnia working with zinnia 0.13 and django 1.5.5, these changes were necessary
