### PR TITLE
Validate whether Entry is registered in admin

### DIFF
--- a/cmsplugin_zinnia/admin.py
+++ b/cmsplugin_zinnia/admin.py
@@ -32,6 +32,9 @@ class EntryPlaceholderAdmin(PlaceholderAdminMixin, EntryAdmin):
 
 
 if ENTRY_BASE_MODEL == 'cmsplugin_zinnia.placeholder.EntryPlaceholder':
-    if admin.site.is_registered(Entry):
-        admin.site.unregister(Entry)
+    try:
+        if admin.site.is_registered(Entry):
+            admin.site.unregister(Entry)
+    except:
+        pass
     admin.site.register(Entry, EntryPlaceholderAdmin)


### PR DESCRIPTION
Fix this bug

``` python
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Library/Python/2.7/site-packages/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
  File "/Library/Python/2.7/site-packages/django/core/handlers/wsgi.py", line 187, in __call__
    self.load_middleware()
  File "/Library/Python/2.7/site-packages/django/core/handlers/base.py", line 47, in load_middleware
    mw_instance = mw_class()
  File "/Library/Python/2.7/site-packages/django/middleware/locale.py", line 24, in __init__
    for url_pattern in get_resolver(None).url_patterns:
  File "/Library/Python/2.7/site-packages/django/core/urlresolvers.py", line 365, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/Library/Python/2.7/site-packages/django/core/urlresolvers.py", line 360, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/Library/Python/2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/Users/marat/Dev/12trip-cms/ott_cms/urls.py", line 9, in <module>
    admin.autodiscover()
  File "/Library/Python/2.7/site-packages/django/contrib/admin/__init__.py", line 29, in autodiscover
    import_module('%s.admin' % app)
  File "/Library/Python/2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/Users/marat/Dev/12trip-cms/ott_cms/admin.py", line 51, in <module>
    from cmsplugin_zinnia.admin import EntryPlaceholderAdmin
  File "/Library/Python/2.7/site-packages/cmsplugin_zinnia/admin.py", line 35, in <module>
    admin.site.unregister(Entry)
  File "/Library/Python/2.7/site-packages/django/contrib/admin/sites.py", line 107, in unregister
    raise NotRegistered('The model %s is not registered' % model.__name__)
NotRegistered: The model Entry is not registered
```
