### PR TITLE
fix for request not being found in context

### DIFF
--- a/cmsplugin_zinnia/placeholder.py
+++ b/cmsplugin_zinnia/placeholder.py
@@ -48,7 +48,7 @@ class PlaceholderEntry(models.Model):
         context = self.acquire_context()
         try:
             return render_placeholder(self.content_placeholder, context)
-        except AttributeError:
+        except (AttributeError, KeyError):
             # Should happen when ``context`` and ``request``
             # have not been found in the stack.
             pass


### PR DESCRIPTION
Sometimes the request key is not in the context dictionary, preventing the page at /admin/zinnia from loading. This fixes it.