### PR TITLE
Add fields attribute to CalendarEntriesAdminForm.

### DIFF
--- a/cmsplugin_zinnia/forms.py
+++ b/cmsplugin_zinnia/forms.py
@@ -19,3 +19,4 @@ class CalendarEntriesAdminForm(forms.ModelForm):
 
     class Meta:
         model = CalendarEntriesPlugin
+        fields = '__all__'


### PR DESCRIPTION
Django 1.8 requires either the 'fields' or 'exclude' attribute to be set for modelForm. Omitting any definition of the fields to use will result in an ImproperlyConfigured exception. See https://docs.djangoproject.com/en/1.8/ref/forms/models/.