### PR TITLE
Fix 3 System check warnings in LatestEntriesPlugin model

### DIFF
--- a/cmsplugin_zinnia/models.py
+++ b/cmsplugin_zinnia/models.py
@@ -28,16 +28,16 @@ class LatestEntriesPlugin(CMSPlugin):
                  (False, _('Hide featured entries'))))
     categories = models.ManyToManyField(
         'zinnia.Category', verbose_name=_('categories'),
-        blank=True, null=True)
+        blank=True)
     subcategories = models.BooleanField(
         _('include subcategories'), default=True,
         help_text=_('include the entries belonging the subcategories'))
     authors = models.ManyToManyField(
         'zinnia.Author', verbose_name=_('authors'),
-        blank=True, null=True)
+        blank=True)
     tags = models.ManyToManyField(
         'tagging.Tag', verbose_name=_('tags'),
-        blank=True, null=True)
+        blank=True)
 
     number_of_entries = models.PositiveIntegerField(
         _('number of entries'), default=5,


### PR DESCRIPTION
When running `python manage.py migrate` or `python manage.py check` on a Django 1.8 project using `cmsplugin_zinnia` Django issues 3 warnings on the [LatestEntriesPlugin model](https://github.com/django-blog-zinnia/cmsplugin-zinnia/blob/develop/cmsplugin_zinnia/models.py#L19):
```
System check identified some issues:

WARNINGS:
cmsplugin_zinnia.LatestEntriesPlugin.authors: (fields.W340) null has no effect on ManyToManyField.
cmsplugin_zinnia.LatestEntriesPlugin.categories: (fields.W340) null has no effect on ManyToManyField.
cmsplugin_zinnia.LatestEntriesPlugin.tags: (fields.W340) null has no effect on ManyToManyField.
```
I have removed the 3 occurences of `null=True`. We don't need a migration for that, do we?