### PR TITLE
Fix RemovedInDjango19Warning (django.utils.importlib)

### DIFF
--- a/cmsplugin_zinnia/cms_app.py
+++ b/cmsplugin_zinnia/cms_app.py
@@ -1,7 +1,7 @@
 """Application hooks for cmsplugin_zinnia"""
 import warnings
 
-from django.utils.importlib import import_module
+from importlib import import_module
 from django.utils.translation import ugettext_lazy as _
 
 from cms.app_base import CMSApp


### PR DESCRIPTION
Does away with the RemovedInDjango19Warning advertised by Django 1.8.

The [suggested replacement](https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib) `importlib` exists in the [Python 2.7+ and 3](https://docs.python.org/2.7/library/importlib.html#module-importlib) core libraries.

If you want the cmsplugin to be backward compatible with Python 2.6 too, I can add a `try`-`except` construct. Please, let me know!
