### PR TITLE
CMS toolbar: Check user permissions, disable menu items

### DIFF
--- a/cmsplugin_zinnia/cms_toolbar.py
+++ b/cmsplugin_zinnia/cms_toolbar.py
@@ -41,10 +41,10 @@ class ZinniaToolbar(CMSToolbar):
             disabled=not user.has_perm('tagging.change_tag'))
 
         # remove complete menu if all items are disabled
-        for item in zinnia_menu.get_items():
-            if not getattr(item, 'disabled', True):
-                return
-        self.toolbar.remove_item(zinnia_menu)
+        enabled_items = [item for item in zinnia_menu.get_items()
+                         if not getattr(item, 'disabled', True)]
+        if len(enabled_items) == 0:
+            self.toolbar.remove_item(zinnia_menu)
 
 
 toolbar_pool.register(ZinniaToolbar)

--- a/cmsplugin_zinnia/cms_toolbar.py
+++ b/cmsplugin_zinnia/cms_toolbar.py
@@ -9,25 +9,35 @@ from cms.toolbar_pool import toolbar_pool
 class ZinniaToolbar(CMSToolbar):
 
     def populate(self):
+        user = self.request.user
         zinnia_menu = self.toolbar.get_or_create_menu(
             'zinnia-menu', _('Zinnia'))
 
-        url = reverse('admin:zinnia_entry_add')
-        zinnia_menu.add_sideframe_item(_('New entry'), url=url)
+        if user.has_perm('zinnia.add_entry'):
+            url = reverse('admin:zinnia_entry_add')
+            zinnia_menu.add_sideframe_item(_('New entry'), url=url)
 
-        url = reverse('admin:zinnia_category_add')
-        zinnia_menu.add_sideframe_item(_('New category'), url=url)
+        if user.has_perm('zinnia.add_category'):
+            url = reverse('admin:zinnia_category_add')
+            zinnia_menu.add_sideframe_item(_('New category'), url=url)
 
-        zinnia_menu.add_break()
+        if zinnia_menu.get_items():
+            zinnia_menu.add_break()
 
-        url = reverse('admin:zinnia_entry_changelist')
-        zinnia_menu.add_sideframe_item(_('Entries list'), url=url)
+        if user.has_perm('zinnia.change_entry'):
+            url = reverse('admin:zinnia_entry_changelist')
+            zinnia_menu.add_sideframe_item(_('Entries list'), url=url)
 
-        url = reverse('admin:zinnia_category_changelist')
-        zinnia_menu.add_sideframe_item(_('Categories list'), url=url)
+        if user.has_perm('zinnia.change_category'):
+            url = reverse('admin:zinnia_category_changelist')
+            zinnia_menu.add_sideframe_item(_('Categories list'), url=url)
 
-        url = reverse('admin:tagging_tag_changelist')
-        zinnia_menu.add_sideframe_item(_('Tags list'), url=url)
+        if user.has_perm('tagging.change_tag'):
+            url = reverse('admin:tagging_tag_changelist')
+            zinnia_menu.add_sideframe_item(_('Tags list'), url=url)
+
+        if not zinnia_menu.get_items():
+            self.toolbar.remove_item(zinnia_menu)
 
 
 toolbar_pool.register(ZinniaToolbar)

--- a/cmsplugin_zinnia/cms_toolbar.py
+++ b/cmsplugin_zinnia/cms_toolbar.py
@@ -13,31 +13,38 @@ class ZinniaToolbar(CMSToolbar):
         zinnia_menu = self.toolbar.get_or_create_menu(
             'zinnia-menu', _('Zinnia'))
 
-        if user.has_perm('zinnia.add_entry'):
-            url = reverse('admin:zinnia_entry_add')
-            zinnia_menu.add_sideframe_item(_('New entry'), url=url)
+        url = reverse('admin:zinnia_entry_add')
+        zinnia_menu.add_sideframe_item(
+            _('New entry'), url=url,
+            disabled=not user.has_perm('zinnia.add_entry'))
 
-        if user.has_perm('zinnia.add_category'):
-            url = reverse('admin:zinnia_category_add')
-            zinnia_menu.add_sideframe_item(_('New category'), url=url)
+        url = reverse('admin:zinnia_category_add')
+        zinnia_menu.add_sideframe_item(
+            _('New category'), url=url,
+            disabled=not user.has_perm('zinnia.add_category'))
 
-        if zinnia_menu.get_items():
-            zinnia_menu.add_break()
+        zinnia_menu.add_break()
 
-        if user.has_perm('zinnia.change_entry'):
-            url = reverse('admin:zinnia_entry_changelist')
-            zinnia_menu.add_sideframe_item(_('Entries list'), url=url)
+        url = reverse('admin:zinnia_entry_changelist')
+        zinnia_menu.add_sideframe_item(
+            _('Entries list'), url=url,
+            disabled=not user.has_perm('zinnia.change_entry'))
 
-        if user.has_perm('zinnia.change_category'):
-            url = reverse('admin:zinnia_category_changelist')
-            zinnia_menu.add_sideframe_item(_('Categories list'), url=url)
+        url = reverse('admin:zinnia_category_changelist')
+        zinnia_menu.add_sideframe_item(
+            _('Categories list'), url=url,
+            disabled=not user.has_perm('zinnia.change_category'))
 
-        if user.has_perm('tagging.change_tag'):
-            url = reverse('admin:tagging_tag_changelist')
-            zinnia_menu.add_sideframe_item(_('Tags list'), url=url)
+        url = reverse('admin:tagging_tag_changelist')
+        zinnia_menu.add_sideframe_item(
+            _('Tags list'), url=url,
+            disabled=not user.has_perm('tagging.change_tag'))
 
-        if not zinnia_menu.get_items():
-            self.toolbar.remove_item(zinnia_menu)
+        # remove complete menu if all items are disabled
+        for item in zinnia_menu.get_items():
+            if hasattr(item, 'disabled') and not item.disabled:
+                return
+        self.toolbar.remove_item(zinnia_menu)
 
 
 toolbar_pool.register(ZinniaToolbar)

--- a/cmsplugin_zinnia/cms_toolbar.py
+++ b/cmsplugin_zinnia/cms_toolbar.py
@@ -42,7 +42,7 @@ class ZinniaToolbar(CMSToolbar):
 
         # remove complete menu if all items are disabled
         for item in zinnia_menu.get_items():
-            if hasattr(item, 'disabled') and not item.disabled:
+            if not getattr(item, 'disabled', True):
                 return
         self.toolbar.remove_item(zinnia_menu)
 


### PR DESCRIPTION
This PR enhances the user experience in the "Zinnia" menu of the CMS toolbar.
- Menu items for actions that are not available due to lacking permissions are disabled.
- If none of the actions (menu items) are available then the complete "Zinnia" menu is removed from the toolbar.

**Note:** Disabling the actions not available follows Divio's implementation of the toolbar menus. For a "remove items" based implementation see the first commit of this PR.
