### PR TITLE
Ignore KeyError thrown by render_placeholder() in Admin

### DIFF
--- a/cmsplugin_zinnia/admin.py
+++ b/cmsplugin_zinnia/admin.py
@@ -25,8 +25,11 @@ class EntryPlaceholderAdmin(PlaceholderAdminMixin, EntryAdmin):
         of the placeholder
         """
         context = RequestContext(request)
-        content = render_placeholder(entry.content_placeholder, context)
-        entry.content = content or ''
+        try:
+            content = render_placeholder(entry.content_placeholder, context)
+            entry.content = content or ''
+        except KeyError:
+            entry.content = ''
         super(EntryPlaceholderAdmin, self).save_model(
             request, entry, form, change)
 


### PR DESCRIPTION
This PR applies the same hack as PR #45 for `KeyError` being thrown by django CMS'  [render_placeholder](https://github.com/divio/django-cms/blob/3.3.2/cms/plugin_rendering.py#L125) in the Admin (`'request'` is not found as a key in `context`). Changes seem to be saved normally even with `KeyError`s being silently ignored.  :anguished:

See also: https://github.com/divio/django-cms/issues/5646
