### PR TITLE
Make EntryPlaceholder work with django CMS 3.4

### DIFF
--- a/cmsplugin_zinnia/admin.py
+++ b/cmsplugin_zinnia/admin.py
@@ -3,12 +3,13 @@ from django.contrib import admin
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 
-from cms.plugin_rendering import render_placeholder
 from cms.admin.placeholderadmin import PlaceholderAdminMixin
 
 from zinnia.models import Entry
 from zinnia.admin.entry import EntryAdmin
 from zinnia.settings import ENTRY_BASE_MODEL
+
+from .placeholder import render_placeholder
 
 
 class EntryPlaceholderAdmin(PlaceholderAdminMixin, EntryAdmin):
@@ -24,9 +25,8 @@ class EntryPlaceholderAdmin(PlaceholderAdminMixin, EntryAdmin):
         Fill the content field with the interpretation
         of the placeholder
         """
-        context = RequestContext(request)
         try:
-            content = render_placeholder(entry.content_placeholder, context)
+            content = render_placeholder(entry.content_placeholder, request)
             entry.content = content or ''
         except KeyError:
             # https://github.com/django-blog-zinnia/cmsplugin-zinnia/pull/61


### PR DESCRIPTION
A quick fix addressing the changed django CMS API to render the EntryPlaceholder.

Fixes issues #62 and #63.

@Fantomas42 I've seen you've  started a [dedicated branch](https://github.com/django-blog-zinnia/cmsplugin-zinnia/tree/feature/django-cms-3.4) for django CMS 3.4 compatibility. Maybe you still find this useful, as an inspiration or support, even if you prefer not to merge it. 