### PR TITLE
Avoid import render_placeholder error on Django 1

### DIFF
--- a/cmsplugin_zinnia/admin.py
+++ b/cmsplugin_zinnia/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 
-from cms.plugin_rendering import render_placeholder
+from cms.plugin_rendering import PluginContext 
 from cms.admin.placeholderadmin import PlaceholderAdminMixin
 
 from zinnia.models import Entry


### PR DESCRIPTION
fixed error from undefined import render_placeholder