### PR TITLE
Feature/setup tools defined

### DIFF
--- a/cmsplugin_zinnia/cms_menus.py
+++ b/cmsplugin_zinnia/cms_menus.py
@@ -1,6 +1,6 @@
 """Menus for cmsplugin_zinnia"""
 from django.utils.dateformat import format
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.signals import post_save
 from django.db.models.signals import post_delete
 from django.utils.translation import ugettext_lazy as _

--- a/cmsplugin_zinnia/cms_toolbars.py
+++ b/cmsplugin_zinnia/cms_toolbars.py
@@ -1,5 +1,5 @@
 """Toolbar extensions for CMS"""
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from cms.toolbar_base import CMSToolbar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools < 60.7.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Fixed an incompability with setup tools by kludging in what version of setup tools the package can be built with.
Used [sensible defaults](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour) for this. This is essentially a kludge to allow us to continue to use the package but it would be better if actually upgraded the configuration to work with the latest setuptools.
